### PR TITLE
added guard around cast in EntityChocobo (fixes #23)

### DIFF
--- a/src/main/java/net/xalcon/chococraft/common/entities/EntityChocobo.java
+++ b/src/main/java/net/xalcon/chococraft/common/entities/EntityChocobo.java
@@ -342,9 +342,10 @@ public class EntityChocobo extends EntityTameable
 	@Override
 	public void travel(float strafe, float vertical, float forward)
 	{
-		EntityPlayer rider = (EntityPlayer) this.getControllingPassenger();
-		if (rider != null)
+		if (this.getControllingPassenger() instanceof EntityPlayer)
 		{
+			EntityPlayer rider = (EntityPlayer) this.getControllingPassenger();
+			
 			this.prevRotationYaw = rider.rotationYaw;
 			this.rotationYaw = rider.rotationYaw;
 			this.rotationPitch = rider.rotationPitch * 0.5F;


### PR DESCRIPTION
I added a guard around the cast in EntityChocobo::travel(), which fixes a bug involving riders that aren't `EntityPlayer`s.